### PR TITLE
service logos now show instead of name under availability

### DIFF
--- a/src/components/Questionaire.jsx
+++ b/src/components/Questionaire.jsx
@@ -11,17 +11,9 @@ const questions = {
             'title': 'Select all streaming services to search',
             'type': 'tagbox',
             'choices': [
-                { 
-                    'text': 'Netflix',
-                    'value': 'netflix'
-                },
                 {
-                    'text': 'Hulu',
-                    'value': 'hulu.subscription'
-                },
-                {
-                    'text': 'Prime Video',
-                    'value': 'prime.subscription'
+                    'text': 'Apple TV',
+                    'value': 'apple.subscription'
                 },
                 {
                     'text': 'Disney+',
@@ -32,8 +24,24 @@ const questions = {
                     'value': 'hbo'
                 },
                 {
+                    'text': 'Hulu',
+                    'value': 'hulu.subscription'
+                },
+                { 
+                    'text': 'Netflix',
+                    'value': 'netflix'
+                },
+                {
+                    'text': 'Paramount+',
+                    'value': 'paramount.subscription'
+                },
+                {
                     'text': 'Peacock',
                     'value': 'peacock.subscription'
+                },
+                {
+                    'text': 'Prime Video',
+                    'value': 'prime.subscription'
                 }
             ],
             'isRequired': true,

--- a/src/components/RouletteWheel.jsx
+++ b/src/components/RouletteWheel.jsx
@@ -2,12 +2,18 @@ import React, { useState } from 'react'
 import axios from 'axios'
 import genericPoster from '../../images/generic_poster.png'
 import '../styles/wheelStyle.css'
+import ServicesList from './ServicesList.jsx'
 
 function RouletteWheel (props) { 
     if (props.moviesList.length > 0) {
         const movies = props.moviesList
         const movieChoice = props.movieChoice
         const chosenMovieID = movieChoice.tmdbId
+        const streamingServices = movieChoice.streamingInfo.us.map((service) => {
+            return service.service
+        }).filter((service, index, servicesArray) => {
+            return servicesArray.indexOf(service) === index
+        })
         const [ moviePosterObj, setMoviePosterObj ] = useState({
             url: '',
             title: ''
@@ -37,11 +43,8 @@ function RouletteWheel (props) {
                         <p id='overviewLabel'>Overview</p>
                         <p id='overviewText'>{movieChoice.overview}</p>
                         <br />
-                        <p>{'Available on:' + movieChoice.streamingInfo.us.map((service) => {
-                            return ' ' + service.service
-                        }).filter((service, index, servicesArray) => {
-                            return servicesArray.indexOf(service) === index
-                        })}</p>
+                        <p>Available on: </p>
+                        <ServicesList streamingServices={streamingServices} />
                     </div>
                 </div>
             </div>

--- a/src/components/ServicesList.jsx
+++ b/src/components/ServicesList.jsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import '../styles/wheelStyle.css'
+
+function ServicesList (props) {
+    const services = props.streamingServices
+    const baseURL = 'https://image.tmdb.org/t/p/original'
+    const serviceImageURL = {
+        'netflix': '/wwemzKWzjKYJFfCeiB57q3r4Bcm.png',
+        'hulu': '/pqUTCleNUiTLAVlelGxUgWn1ELh.png',
+        'prime': '/ifhbNuuVnlwYy5oXA5VIb2YR8AZ.png',
+        'hbo': '/nmU0UMDJB3dRRQSTUqawzF2Od1a.png',
+        'disney': '/uzKjVDmQ1WRMvGBb7UNRE0wTn1H.png',
+        'peacock': '/gIAcGTjKKr0KOHL5s4O36roJ8p7.png',
+        'apple': '/4KAy34EHvRM25Ih8wb82AuGU7zJ.png',
+        'paramount': '/fi83B1oztoS47xxcemFdPMhIzK.png'
+    }
+
+    return(
+        services.map((service) => {
+            const logoURL = baseURL + serviceImageURL[service]
+            console.log(services)
+            const altText = 'Streaming service logo for ' + service
+            if (serviceImageURL[service]) {
+                return (<img key={service} className='streamingLogos' src={logoURL} alt={altText} />)
+            } else {
+                return (<p className='serviceNoLogo'>{service}</p>)
+            }
+        })
+    )
+}
+
+export default ServicesList

--- a/src/styles/wheelStyle.css
+++ b/src/styles/wheelStyle.css
@@ -27,3 +27,11 @@
     padding-left: 10px;
     background-color: #711324;
 }
+
+.streamingLogos {
+    max-width: 85px;
+    max-height: 45px;
+    padding-bottom: 5px;
+    padding-left: 10px;
+    padding-right: 10px;
+}


### PR DESCRIPTION
- Logos for all streaming services (those that are available choices in form) show instead of name under "Available on:"
- If streaming service is not a choice in the above form, the name is shown as text
- style added to className for logos to keep spacing and sizes even
- Paramount+ and Apple TV added as options in form